### PR TITLE
Update updateChecker.js

### DIFF
--- a/modules/updateChecker.js
+++ b/modules/updateChecker.js
@@ -24,7 +24,7 @@ const check = exports.check = () => {
         break;
     }
 
-    return got('https://api.github.com/repos/ethereum/mist/releases', {
+    return got('https://api.github.com/repos/ellaism-io/ellagem/releases', {
         timeout: 3000,
         json: true,
     })


### PR DESCRIPTION
Update to fix "check for updates.." within Ellagem

#### What does it do?

Change Github API to use the correct URI path. https://api.github.com/repos/ellaism-io/ellagem/releases

#### Any helpful background information?

This is currently broken. 

#### Which code should the reviewer start with?

We need to update the github with the proper release information, I will leave that to you @riddlez666 

#### New dependencies? What are they used for?

None.

#### Relevant screenshots?
No.