### PR TITLE
Correct path on Mac in settings.js

### DIFF
--- a/modules/settings.js
+++ b/modules/settings.js
@@ -285,7 +285,7 @@ class Settings {
         ipcPath = this.userHomePath;
 
         if (process.platform === 'darwin') {
-            ipcPath += '/Library/ellaism/mainnet/geth.ipc';
+            ipcPath += '/Library/Ellaism/mainnet/geth.ipc';
         } else if (process.platform === 'freebsd' ||
        process.platform === 'linux' ||
        process.platform === 'sunos') {


### PR DESCRIPTION
Fixes path on Mac

Path is case sensitive.  This should be /Library/Ellaism instead of /Library/ellaism

